### PR TITLE
button border radius to 0 and remove input outline

### DIFF
--- a/sass/buttons.scss
+++ b/sass/buttons.scss
@@ -7,6 +7,7 @@
 button {
   border: none;
   outline: none;
+  border-radius: 0;
 }
 
 button, .btn {

--- a/sass/forms.scss
+++ b/sass/forms.scss
@@ -8,6 +8,7 @@ input[type="text"] {
   border: 2px solid black;
   padding: 12px;
   width: 100%;
+  outline: none;
 }
 
 .error-label {


### PR DESCRIPTION
Outline to none on input[type="text"] and textarea, button radius nullify in response to new default on Mac Chrome? (doesn't happen on Win Chrome, hehe)